### PR TITLE
feat: Add installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@
 This python script will turn your linux PC into a bluetooth speaker.
 It allows your devices (phone, tablet, etc) to connect without authentication to the PC and play the sound to your alsa card or pulseaudio.
 
+## Installation
+
+To use this project, you might consider using the premade installer.
+It was tested on Debian 12 with the usual Gnome desktop environment.
+
+In order to use the installer, clone the repository and execute the following commands in your terminal:
+
+```bash
+# (repo was cloned, resides in bt-audio)
+cd bt-audio
+chmod +x install.sh
+./install.sh
+```
+
 ## Requirements
 * Bluez 5.x
 * Gstreamer

--- a/bt-audio.service
+++ b/bt-audio.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Utility to use Linux as a bluetooth speaker
+Documentation=https://github.com/gmsoft-tuxicoman/bt-audio
+After=network-online.target bluetooth.target
+
+[Service]
+Type=simple
+# User=root
+
+WorkingDirectory=/usr/bin/bt-audio
+ExecStart=/usr/bin/bt-audio/run.sh
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/install.sh
+++ b/install.sh
@@ -25,11 +25,6 @@ echo "Installing source code..."
 
 sudo mkdir -p "${APP_ROOT}" || exit 1
 
-# sudo python3 -m venv "${APP_ROOT}" || exit 1
-
-# source "${APP_ROOT}/bin/activate"
-# pip3 install dbus-python
-
 sudo cp ./bt-audio.py "${APP_ROOT}/" || exit 1
 
 sudo touch "${APP_ROOT}/run.sh" || exit 1

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/bash
+
+APP_ROOT=/usr/bin/bt-audio
+
+echo "Installing application at '${APP_ROOT}'..."
+
+#
+# Install packages.
+#
+
+echo "Installing required packages ($PACKAGES)..."
+
+sudo apt install -y --fix-missing \
+    bluez bluez-tools \
+    pulseaudio-module-bluetooth \
+    gstreamer1.0-alsa dbus \
+    python3 || exit 1
+sudo systemctl enable bluetooth --now || exit 1
+
+#
+# Install code files
+#
+
+echo "Installing source code..."
+
+sudo mkdir -p "${APP_ROOT}" || exit 1
+
+# sudo python3 -m venv "${APP_ROOT}" || exit 1
+
+# source "${APP_ROOT}/bin/activate"
+# pip3 install dbus-python
+
+sudo cp ./bt-audio.py "${APP_ROOT}/" || exit 1
+
+sudo touch "${APP_ROOT}/run.sh" || exit 1
+
+sudo cp run.sh "${APP_ROOT}/" || exit 1
+sudo chmod +x "${APP_ROOT}/run.sh" || exit 1
+
+#
+# Install systemd service
+#
+
+echo "Installing Systemd service..."
+
+sudo cp bt-audio.service /etc/systemd/system/ || exit 1
+sudo systemctl daemon-reload || exit 1
+sudo systemctl enable bt-audio --now || exit 1
+sudo systemctl status bt-audio || exit 1
+
+echo "Installation steps completed."

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ echo "Installing required packages ($PACKAGES)..."
 sudo apt install -y --fix-missing \
     bluez bluez-tools \
     pulseaudio-module-bluetooth \
-    gstreamer1.0-alsa dbus \
+    gstreamer1.0-alsa python3-dbus dbus \
     python3 || exit 1
 sudo systemctl enable bluetooth --now || exit 1
 

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ echo "Installing required packages ($PACKAGES)..."
 sudo apt install -y --fix-missing \
     bluez bluez-tools \
     pulseaudio-module-bluetooth \
-    gstreamer1.0-alsa python3-dbus dbus \
+    gstreamer-1.0 gstreamer1.0-alsa python3-dbus dbus \
     python3 || exit 1
 sudo systemctl enable bluetooth --now || exit 1
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+python3 ./bt-audio.py


### PR DESCRIPTION
This PR adds a Systemd Service file and a short installation script,
allowing users to deploy this software in an easy manner.
In order to install `bt-audio`, the user clones this repository and executes the following commands:

```bash
# (repo was cloned)
$ cd bt-audio
$ ./install.sh
```

